### PR TITLE
utilisation de requires(dev=True) deprecated...

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -44,7 +44,7 @@ class QtConan(ConanFile):
     def requirements(self):
         if self.settings.os == "Windows":
             if self.options.openssl == "yes":
-                self.requires("OpenSSL/1.0.2l@conan/stable", dev=True)
+                self.build_requires("OpenSSL/1.0.2l@conan/stable")
             elif self.options.openssl == "linked":
                 self.requires("OpenSSL/1.0.2l@conan/stable")
 


### PR DESCRIPTION
> Deprecation: dev_requires have been removed (it was not documented, but accessible via the requires(dev=True) parameter. Superseded by build_requires.